### PR TITLE
Add real shuffle!

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Currently the following trigger words are available:
 * `stop` - Stops playback and resets to the beginning of the current track.
 * `skip` - Skips to the next track in the playlist.
 * `random` - Toggles random mode on or off.
+* `shuffle` - Toggles shuffle mode on or off.
 * `vol [up|down|0..10]` Turns the volume either up/down one notch or directly to a step between 0 (mute) and 10 (full blast). Also goes to eleven.
 * `list [command] [options]` - See playlists section below.
 * `status` - Shows the currently playing song, playlist and whether you're shuffling or not.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Currently the following trigger words are available:
 * `play [Spotify URI]` - Starts/resumes playback if no URI is provided. If a URI is given, immediately switches to the linked track.
 * `pause` - Pauses playback at the current time.
 * `stop` - Stops playback and resets to the beginning of the current track.
-* `skip` - Skips (or shuffles) to the next track in the playlist.
-* `shuffle` - Toggles shuffle on or off.
+* `skip` - Skips to the next track in the playlist.
+* `random` - Toggles random mode on or off.
 * `vol [up|down|0..10]` Turns the volume either up/down one notch or directly to a step between 0 (mute) and 10 (full blast). Also goes to eleven.
 * `list [command] [options]` - See playlists section below.
 * `status` - Shows the currently playing song, playlist and whether you're shuffling or not.

--- a/lib/slack_interface/request_handler.coffee
+++ b/lib/slack_interface/request_handler.coffee
@@ -32,10 +32,17 @@ class SlackInterfaceRequestHandler
 
               when 'random'
                 @spotify.toggle_random()
-                reply_data['text'] = if @spotify.random
+                reply_data['text'] = if @spotify.state.random
                     "CHAOS"
                   else
                     "Don't be a square."
+
+              when 'shuffle'
+                @spotify.toggle_shuffle()
+                reply_data['text'] = if @spotify.state.shuffle
+                    "ERRYDAY I'M SHUFFLING."
+                  else
+                    "I am no longer shuffling. Thanks for ruining my fun."
 
               when 'vol'
                 if @auth.args[0]?
@@ -64,21 +71,31 @@ class SlackInterfaceRequestHandler
                   reply_data['text'] = str
 
               when 'status'
-                randomPhrase = if @spotify.random then " and tracks are being chosen at random" else ""
+                playlistOrderPhrase = if @spotify.state.shuffle
+                    " and it is being shuffled"
+                  else if @spotify.state.random
+                    " and tracks are being chosen at random"
+                  else
+                    ""
+
                 if @spotify.is_paused()
                   reply_data['text'] = "Playback is currently *paused* on a song titled *#{@spotify.state.track.name}* from *#{@spotify.state.track.artists}*.\nYour currently selected playlist is named *#{@spotify.state.playlist.name}*#{randomPhrase}. Resume playback with `play`."
                 else if !@spotify.is_playing()
                   reply_data['text'] = "Playback is currently *stopped*. You can start it again by choosing an available `list`."
                 else
                   reply_data['text'] = "You are currently letting your ears feast on the beautiful tunes titled *#{@spotify.state.track.name}* from *#{@spotify.state.track.artists}*.\nYour currently selected playlist is named *#{@spotify.state.playlist.name}*#{randomPhrase}."
+
               when 'help'
-                reply_data['text'] = "You seem lost. Here is a list of commands that are available to you:   \n   \n*Commands*\n> `play [Spotify URI]` - Starts/resumes playback if no URI is provided. If a URI is given, immediately switches to the linked track.\n> `pause` - Pauses playback at the current time.\n> `stop` - Stops playback and resets to the beginning of the current track.\n> `skip` - Skips to the next track in the playlist.\n> `random` - Toggles random mode on or off.\n> `vol [up|down|0..10]` Turns the volume either up/down one notch or directly to a step between `0` (mute) and `10` (full blast). Also goes to `11`.\n> `mute` - Same as `vol 0`.\n> `unmute` - Same as `vol 0`.\n> `status` - Shows the currently playing song, playlist and whether you're in random mode or not.\n> `voteban` - Cast a vote to have the current track banned \n> `banned` - See tracks that are currently banned \n> `help` - Shows a list of commands with a short explanation.\n   \n*Playlists*\n> `list add <name> <Spotify URI>` - Adds a list that can later be accessed under <name>.\n> `list remove <name>` - Removes the specified list.\n> `list rename <old name> <new name>` - Renames the specified list.\n> `list <name>` - Selects the specified list and starts playback."
+                reply_data['text'] = "You seem lost. Here is a list of commands that are available to you:   \n   \n*Commands*\n> `play [Spotify URI]` - Starts/resumes playback if no URI is provided. If a URI is given, immediately switches to the linked track.\n> `pause` - Pauses playback at the current time.\n> `stop` - Stops playback and resets to the beginning of the current track.\n> `skip` - Skips to the next track in the playlist.\n> `random` - Toggles random mode on or off.\n> `shuffle` - Toggles shuffle mode on or off.\n> `vol [up|down|0..10]` Turns the volume either up/down one notch or directly to a step between `0` (mute) and `10` (full blast). Also goes to `11`.\n> `mute` - Same as `vol 0`.\n> `unmute` - Same as `vol 0`.\n> `status` - Shows the currently playing song, playlist and whether you're in random mode or not.\n> `voteban` - Cast a vote to have the current track banned \n> `banned` - See tracks that are currently banned \n> `help` - Shows a list of commands with a short explanation.\n   \n*Playlists*\n> `list add <name> <Spotify URI>` - Adds a list that can later be accessed under <name>.\n> `list remove <name>` - Removes the specified list.\n> `list rename <old name> <new name>` - Renames the specified list.\n> `list <name>` - Selects the specified list and starts playback."
+
               when 'playbettermusic'
                 status = @spotify.set_playlist 'sb-better-music'
                 reply_data['text'] = 'Oh good idea!'
+
               when 'fuckyoudoug'
                 @spotify.play 'spotify:track:1ExT2IobvisyruAWTmlhoS'
                 reply_data['text'] = 'Yeah fuck that guy!'
+
               when 'voteban'
                 if status = @spotify.banCurrentSong(@auth.user)
                   reply_data['text'] = "#{@spotify.state.track.name} is #{status}"

--- a/lib/slack_interface/request_handler.coffee
+++ b/lib/slack_interface/request_handler.coffee
@@ -30,9 +30,12 @@ class SlackInterfaceRequestHandler
                 else
                     @spotify.play()
 
-              when 'shuffle'
-                @spotify.toggle_shuffle()
-                reply_data['text'] = if @spotify.shuffle then "ERRYDAY I'M SHUFFLING." else "I am no longer shuffling. Thanks for ruining my fun."
+              when 'random'
+                @spotify.toggle_random()
+                reply_data['text'] = if @spotify.random
+                    "CHAOS"
+                  else
+                    "Don't be a square."
 
               when 'vol'
                 if @auth.args[0]?
@@ -61,15 +64,15 @@ class SlackInterfaceRequestHandler
                   reply_data['text'] = str
 
               when 'status'
-                shuffleword = if @spotify.shuffle then '' else ' not'
+                randomPhrase = if @spotify.random then " and tracks are being chosen at random" else ""
                 if @spotify.is_paused()
-                  reply_data['text'] = "Playback is currently *paused* on a song titled *#{@spotify.state.track.name}* from *#{@spotify.state.track.artists}*.\nYour currently selected playlist, which you are#{shuffleword} shuffling through, is named *#{@spotify.state.playlist.name}*. Resume playback with `play`."
+                  reply_data['text'] = "Playback is currently *paused* on a song titled *#{@spotify.state.track.name}* from *#{@spotify.state.track.artists}*.\nYour currently selected playlist is named *#{@spotify.state.playlist.name}*#{randomPhrase}. Resume playback with `play`."
                 else if !@spotify.is_playing()
                   reply_data['text'] = "Playback is currently *stopped*. You can start it again by choosing an available `list`."
                 else
-                  reply_data['text'] = "You are currently letting your ears feast on the beautiful tunes titled *#{@spotify.state.track.name}* from *#{@spotify.state.track.artists}*.\nYour currently selected playlist, which you are#{shuffleword} shuffling through, is named *#{@spotify.state.playlist.name}*."
+                  reply_data['text'] = "You are currently letting your ears feast on the beautiful tunes titled *#{@spotify.state.track.name}* from *#{@spotify.state.track.artists}*.\nYour currently selected playlist is named *#{@spotify.state.playlist.name}*#{randomPhrase}."
               when 'help'
-                reply_data['text'] = "You seem lost. Here is a list of commands that are available to you:   \n   \n*Commands*\n> `play [Spotify URI]` - Starts/resumes playback if no URI is provided. If a URI is given, immediately switches to the linked track.\n> `pause` - Pauses playback at the current time.\n> `stop` - Stops playback and resets to the beginning of the current track.\n> `skip` - Skips (or shuffles) to the next track in the playlist.\n> `shuffle` - Toggles shuffle on or off.\n> `vol [up|down|0..10]` Turns the volume either up/down one notch or directly to a step between `0` (mute) and `10` (full blast). Also goes to `11`.\n> `mute` - Same as `vol 0`.\n> `unmute` - Same as `vol 0`.\n> `status` - Shows the currently playing song, playlist and whether you're shuffling or not.\n> `voteban` - Cast a vote to have the current track banned \n> `banned` - See tracks that are currently banned \n> `help` - Shows a list of commands with a short explanation.\n   \n*Playlists*\n> `list add <name> <Spotify URI>` - Adds a list that can later be accessed under <name>.\n> `list remove <name>` - Removes the specified list.\n> `list rename <old name> <new name>` - Renames the specified list.\n> `list <name>` - Selects the specified list and starts playback."
+                reply_data['text'] = "You seem lost. Here is a list of commands that are available to you:   \n   \n*Commands*\n> `play [Spotify URI]` - Starts/resumes playback if no URI is provided. If a URI is given, immediately switches to the linked track.\n> `pause` - Pauses playback at the current time.\n> `stop` - Stops playback and resets to the beginning of the current track.\n> `skip` - Skips to the next track in the playlist.\n> `random` - Toggles random mode on or off.\n> `vol [up|down|0..10]` Turns the volume either up/down one notch or directly to a step between `0` (mute) and `10` (full blast). Also goes to `11`.\n> `mute` - Same as `vol 0`.\n> `unmute` - Same as `vol 0`.\n> `status` - Shows the currently playing song, playlist and whether you're in random mode or not.\n> `voteban` - Cast a vote to have the current track banned \n> `banned` - See tracks that are currently banned \n> `help` - Shows a list of commands with a short explanation.\n   \n*Playlists*\n> `list add <name> <Spotify URI>` - Adds a list that can later be accessed under <name>.\n> `list remove <name>` - Removes the specified list.\n> `list rename <old name> <new name>` - Renames the specified list.\n> `list <name>` - Selects the specified list and starts playback."
               when 'playbettermusic'
                 status = @spotify.set_playlist 'sb-better-music'
                 reply_data['text'] = 'Oh good idea!'

--- a/lib/spotify_handler.coffee
+++ b/lib/spotify_handler.coffee
@@ -217,7 +217,7 @@ class SpotifyHandler
 
   # Handles the actual playback once the track object has been loaded from Spotify
   _play_callback: (track) ->
-    if @is_banned(@_sanitize_link(track.link))
+    if @is_banned(@_sanitize_link(track.link)) || !track.availability
       @skip()
     else
       @state.track.object = track

--- a/lib/spotify_handler.coffee
+++ b/lib/spotify_handler.coffee
@@ -24,7 +24,7 @@ class SpotifyHandler
     @paused = false
 
     @state = {
-      shuffle: true
+      random: true
       track:
         object: null
         index: 0
@@ -148,9 +148,9 @@ class SpotifyHandler
     return
 
 
-  # Toggles shuffle on and off. MAGIC!
-  toggle_shuffle: ->
-    @shuffle = !@shuffle
+  # Toggles random on and off. MAGIC!
+  toggle_random: ->
+    @random = !@random
 
 
   is_playing: ->
@@ -212,7 +212,7 @@ class SpotifyHandler
 
   # Gets the next track from the playlist.
   get_next_track: ->
-    if @shuffle
+    if @random
       @state.track.index = Math.floor(Math.random() * @state.playlist.object.numTracks)
     else
       @state.track.index = ++@state.track.index % @state.playlist.object.numTracks

--- a/lib/spotify_handler.coffee
+++ b/lib/spotify_handler.coffee
@@ -1,3 +1,5 @@
+_ = require 'lodash'
+
 class SpotifyHandler
   constructor: (options) ->
     @spotify = options.spotify
@@ -24,7 +26,8 @@ class SpotifyHandler
     @paused = false
 
     @state = {
-      random: true
+      random: false
+      shuffle: true
       track:
         object: null
         index: 0
@@ -33,6 +36,7 @@ class SpotifyHandler
       playlist:
         name: null
         object: null
+        shuffledTracks: null
     }
 
     @playlists = @storage.getItem('playlists') || {}
@@ -90,6 +94,7 @@ class SpotifyHandler
     @state.playlist.object.on
       tracksAdded: @update_playlist.bind(this)
       tracksRemoved: @update_playlist.bind(this)
+    @_shuffle_playlist(playlist) if @state.shuffle
     return
 
 
@@ -150,7 +155,21 @@ class SpotifyHandler
 
   # Toggles random on and off. MAGIC!
   toggle_random: ->
-    @random = !@random
+    @state.random = !@state.random
+
+    # We don't want to simultaneously be running shuffle
+    # and random, so turn off shuffle if random is active
+    @state.shuffle = false if @state.random
+
+  toggle_shuffle: ->
+    @state.shuffle = !@state.shuffle
+    @state.track.index = 0
+
+    if @state.shuffle
+      # We don't want to simultaneously be running random
+      # and shuffle, so turn off random is shuffle is active
+      @state.random = false
+      @_shuffle_playlist(@state.playlist.object)
 
 
   is_playing: ->
@@ -210,14 +229,26 @@ class SpotifyHandler
       @spotify.player.play @state.track.object
       @playing = true
 
-  # Gets the next track from the playlist.
+  # Gets the next track from the playlist. Uses modulus to easily
+  # restart the playlist once it has played all the way through
   get_next_track: ->
-    if @random
-      @state.track.index = Math.floor(Math.random() * @state.playlist.object.numTracks)
-    else
-      @state.track.index = ++@state.track.index % @state.playlist.object.numTracks
-    @state.playlist.object.getTrack(@state.track.index)
+    index = if @state.shuffle
+        @_translate_shuffled_track_index(@state.track.index++ % @state.playlist.object.numTracks)
+      else if @state.random
+        @state.track.index = Math.floor(Math.random() * @state.playlist.object.numTracks)
+      else
+        @state.track.index++ % @state.playlist.object.numTracks
 
+    @state.playlist.object.getTrack(index)
+
+  _shuffle_playlist: (playlist) ->
+    @state.playlist.shuffledTracks = _.shuffle(playlist.getTracks())
+
+  _translate_shuffled_track_index: (shuffledIndex) ->
+    track = @state.playlist.shuffledTracks[shuffledIndex]
+    translatedIndex = _.findIndex(@state.playlist.object.getTracks(), link: track.link)
+
+    return translatedIndex
 
   # Changes the current playlist and starts playing.
   # Since the playlist might have loaded before we can attach our callback, the actual playlist-functionality
@@ -242,7 +273,8 @@ class SpotifyHandler
     @update_playlist null, playlist
 
     @state.track.index = 0
-    @play @state.playlist.object.getTrack(@state.track.index)
+    @play @get_next_track()
+
     # Also store the name as our last_playlist for the next time we start up
     @storage.setItem 'last_playlist', name
     return

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "apiserver": "^0.3.1",
     "coffee-script": "^1.8.0",
+    "lodash": "^3.10.1",
     "node-persist": "0.0.2"
   }
 }


### PR DESCRIPTION
## Why?
- Our shuffle was just picking songs at random whenever going to the next song. This wasn't great because it led to a lot songs being played multiple times during the course of a day.
## What changed?
- The old shuffle method was renamed to `random` in case somebody really liked that mode
- A new shuffle method was added that stores a shuffled version of the tracks in a playlist. The list of shuffled tracks will get reshuffled when changing playlists, when adding or removing a song from a playlist (via the Slack channel, not the Spotify app), and when toggling shuffle on and off.
- Fixed a bug where unavailable tracks that were on the playlist would cause the app to crash
